### PR TITLE
feat: add custom config for rclone feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ backup:
   
 upload:
   enabled: true
+  rclone_config_path: /etc/tenangdb/rclone.conf
   destination: "minio:bucket/backups/"
 ```
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -42,6 +42,7 @@ backup:
 upload:
   enabled: false # Upload to remote storage is disabled
 #   rclone_path: /usr/bin/rclone  # Path to rclone binary (commented out)
+#   rclone_config_path: /etc/tenangdb/rclone.conf  # Path to rclone config file (commented out)
 #   destination: "idriveomni:sgp1-omni/databases/"  # Remote destination path (commented out)
 #   timeout: 300  # Upload timeout in seconds (commented out)
 #   retry_count: 3  # Number of upload retry attempts (commented out)

--- a/internal/backup/cleanup.go
+++ b/internal/backup/cleanup.go
@@ -75,7 +75,14 @@ func (c *CleanupService) verifyFileExistsInCloud(localPath, backupDir string) bo
 		rclonePath = "/usr/bin/rclone"
 	}
 
-	cmd := exec.Command(rclonePath, "lsf", remotePath)
+	args := []string{"lsf", remotePath}
+	
+	// Add config path if specified
+	if c.uploadConfig.RcloneConfigPath != "" {
+		args = append(args, "--config", c.uploadConfig.RcloneConfigPath)
+	}
+
+	cmd := exec.Command(rclonePath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		c.logger.WithError(err).Debugf("File %s not found in cloud or rclone error", remotePath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,11 +58,12 @@ type MyloaderConfig struct {
 }
 
 type UploadConfig struct {
-	Enabled     bool   `mapstructure:"enabled"`
-	RclonePath  string `mapstructure:"rclone_path"`
-	Destination string `mapstructure:"destination"`
-	Timeout     int    `mapstructure:"timeout"`
-	RetryCount  int    `mapstructure:"retry_count"`
+	Enabled          bool   `mapstructure:"enabled"`
+	RclonePath       string `mapstructure:"rclone_path"`
+	RcloneConfigPath string `mapstructure:"rclone_config_path"`
+	Destination      string `mapstructure:"destination"`
+	Timeout          int    `mapstructure:"timeout"`
+	RetryCount       int    `mapstructure:"retry_count"`
 }
 
 type LoggingConfig struct {
@@ -142,6 +143,7 @@ func setDefaults() {
 
 	viper.SetDefault("upload.enabled", true)
 	viper.SetDefault("upload.rclone_path", "/usr/bin/rclone")
+	viper.SetDefault("upload.rclone_config_path", "~/.config/rclone/rclone.conf")
 	viper.SetDefault("upload.timeout", 300)
 	viper.SetDefault("upload.retry_count", 3)
 

--- a/internal/upload/service.go
+++ b/internal/upload/service.go
@@ -68,6 +68,11 @@ func (s *Service) uploadFile(ctx context.Context, filePath string) error {
 		"--checksum",
 	}
 
+	// Add config path if specified
+	if s.config.RcloneConfigPath != "" {
+		args = append(args, "--config", s.config.RcloneConfigPath)
+	}
+
 	cmd := exec.CommandContext(uploadCtx, s.config.RclonePath, args...)
 
 	// Execute command
@@ -96,6 +101,11 @@ func (s *Service) CleanupRemote(ctx context.Context, retentionDays int) error {
 		s.config.Destination,
 		"--min-age", fmt.Sprintf("%dd", retentionDays),
 		"--dry-run", // Remove this flag in production
+	}
+
+	// Add config path if specified
+	if s.config.RcloneConfigPath != "" {
+		args = append(args, "--config", s.config.RcloneConfigPath)
 	}
 
 	cmd := exec.CommandContext(cleanupCtx, s.config.RclonePath, args...)


### PR DESCRIPTION
add custom for feature for rclone with the the following implemention belows:
```
upload:
  enabled: true
  rclone_config_path: /etc/tenangdb/rclone.conf # new
  destination: "minio:bucket/backups/"
```