### PR TITLE
feat: update clean format.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -161,7 +161,7 @@ func runBackup(configFile, logLevel string, dryRun bool, databases string) {
 			log.WithError(err).Error("Backup process failed")
 			os.Exit(1)
 		}
-		log.Info("✅ Backup process completed successfully")
+		log.Info("✅ All backup process completed successfully")
 	case <-sigChan:
 		log.Info("Received shutdown signal, gracefully shutting down...")
 		cancel()
@@ -181,7 +181,7 @@ func run(cmd *cobra.Command, args []string) {
 	
 	// Show deprecation notice for backward compatibility
 	log := logger.NewLogger(logLevel)
-	log.Warn("DEPRECATED: Running tenangdb without 'backup' subcommand is deprecated. Use 'tenangdb backup' instead.")
+	log.Debug("DEPRECATED: Running tenangdb without 'backup' subcommand is deprecated. Use 'tenangdb backup' instead.")
 	
 	// Call the new backup function for backward compatibility
 	runBackup(configFile, logLevel, dryRun, databases)

--- a/internal/backup/service.go
+++ b/internal/backup/service.go
@@ -82,8 +82,8 @@ func (s *Service) Run(ctx context.Context) error {
 	s.metricsStorage.SetTotalDatabases(s.stats.TotalDatabases)
 	s.metricsStorage.SetBackupProcessActive(true)
 
-	s.logger.Info("Starting database backup process")
-	s.logger.WithField("total_databases", s.stats.TotalDatabases).Info("Backup statistics")
+	s.logger.Debug("🚀 Starting database backup process")
+	s.logger.WithField("total_databases", s.stats.TotalDatabases).Debug("📊 Backup statistics")
 
 	// Create backup directory if it doesn't exist
 	if err := s.createBackupDirectory(); err != nil {
@@ -120,7 +120,7 @@ func (s *Service) processDatabasesBatch(ctx context.Context) error {
 		}
 
 		batch := databases[i:end]
-		s.logger.WithField("batch", fmt.Sprintf("%d-%d", i+1, end)).Info("Processing batch")
+		s.logger.WithField("batch", fmt.Sprintf("%d-%d", i+1, end)).Debug("⚙️ Processing batch")
 
 		if err := s.processBatch(ctx, batch, concurrency); err != nil {
 			s.logger.WithError(err).Error("Batch processing failed")
@@ -158,7 +158,7 @@ func (s *Service) processBatch(ctx context.Context, databases []string, concurre
 
 func (s *Service) processDatabase(ctx context.Context, dbName string) {
 	log := s.logger.WithDatabase(dbName)
-	log.Info("Starting database backup")
+	log.Debug("🔄 Starting database backup")
 
 	backupStartTime := time.Now()
 
@@ -167,7 +167,7 @@ func (s *Service) processDatabase(ctx context.Context, dbName string) {
 	backupDuration := time.Since(backupStartTime)
 
 	if err != nil {
-		log.WithError(err).Error("Database backup failed")
+		log.Error("❌ " + dbName + " backup failed: " + err.Error())
 		s.incrementFailedBackups()
 		metrics.RecordBackupEnd(dbName, backupDuration, false, 0)
 		s.metricsStorage.UpdateBackupMetrics(dbName, backupDuration, false, 0)
@@ -181,7 +181,7 @@ func (s *Service) processDatabase(ctx context.Context, dbName string) {
 		backupSize = 0
 	}
 
-	log.WithField("backup_file", backupPath).Info("✅ Database backup completed successfully")
+	log.Info("✅ " + dbName + " backup completed")
 	s.incrementSuccessfulBackups()
 	metrics.RecordBackupEnd(dbName, backupDuration, true, backupSize)
 	s.metricsStorage.UpdateBackupMetrics(dbName, backupDuration, true, backupSize)
@@ -190,12 +190,12 @@ func (s *Service) processDatabase(ctx context.Context, dbName string) {
 	if s.uploader != nil {
 		uploadStartTime := time.Now()
 		if err := s.uploadBackup(ctx, backupPath); err != nil {
-			log.WithError(err).Error("Cloud upload failed")
+			log.Error("❌ " + dbName + " upload failed: " + err.Error())
 			s.incrementFailedUploads()
 			metrics.RecordUploadEnd(dbName, "rclone", time.Since(uploadStartTime), false, 0)
 			s.metricsStorage.UpdateUploadMetrics(dbName, time.Since(uploadStartTime), false, 0)
 		} else {
-			log.Info("📤 Cloud upload completed successfully")
+			log.Info("✅ " + dbName + " upload completed")
 			s.incrementSuccessfulUploads()
 			metrics.RecordUploadEnd(dbName, "rclone", time.Since(uploadStartTime), true, backupSize)
 			s.metricsStorage.UpdateUploadMetrics(dbName, time.Since(uploadStartTime), true, backupSize)


### PR DESCRIPTION
update the stdout clean format with below expected result:
```
Normal operation (info level):
  ✅ pastefy backup completed
  ✅ phpmyadmin backup completed
  ✅ sys backup completed
  🗂️ 3 databases backed up in 1.9s
  ✅ All backup process completed successfully

  Debug mode (--log-level debug):
  🚀 Starting database backup process
  📊 Backup statistics
  ⚙️ Processing batch
  🔄 Starting database backup
  ✅ pastefy backup completed
  ✅ phpmyadmin backup completed
  ✅ sys backup completed
  🗂️ 3 databases backed up in 1.9s
  ✅ All backup process completed successfully

  Error handling:
  ❌ database_name backup failed: connection timeout
  ❌ database_name upload failed: network error

  This gives users a clean, focused output by default while still allowing detailed debugging when needed with --log-level debug.
```