### PR TITLE
feat: add standalone upload command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/abdullahainun/tenangdb/internal/config"
 	"github.com/abdullahainun/tenangdb/internal/logger"
 	"github.com/abdullahainun/tenangdb/internal/metrics"
+	"github.com/abdullahainun/tenangdb/internal/upload"
 	"github.com/abdullahainun/tenangdb/pkg/database"
 
 	"github.com/spf13/cobra"
@@ -70,6 +71,9 @@ func main() {
 
 	// Add init command
 	rootCmd.AddCommand(newInitCommand())
+
+	// Add upload command
+	rootCmd.AddCommand(newUploadCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -2110,4 +2114,76 @@ func loadPartialConfig(configFile string) (*config.Config, error) {
 	}
 	
 	return &cfg, nil
+}
+
+func newUploadCommand() *cobra.Command {
+	var configFile string
+	var logLevel string
+	var sourcePath string
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "Upload an existing backup to cloud storage",
+		Long:  `Upload an existing backup file or directory to cloud storage using rclone, without running a backup first.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runUpload(configFile, logLevel, sourcePath, dryRun)
+		},
+	}
+
+	cmd.Flags().StringVar(&configFile, "config", "", "config file path (auto-discovery if not specified)")
+	cmd.Flags().StringVar(&logLevel, "log-level", "info", "log level (debug, info, warn, error)")
+	cmd.Flags().StringVarP(&sourcePath, "source-path", "s", "", "path to backup file or directory to upload (required)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be uploaded without actually uploading")
+
+	if err := cmd.MarkFlagRequired("source-path"); err != nil {
+		fmt.Printf("Error: Failed to mark source-path flag as required: %v\n", err)
+	}
+
+	return cmd
+}
+
+func runUpload(configFile, logLevel, sourcePath string, dryRun bool) {
+	ctx := context.Background()
+
+	cfg, err := config.LoadConfig(configFile)
+	if err != nil {
+		log := logger.NewLogger(logLevel)
+		log.WithError(err).Fatal("Failed to load configuration")
+	}
+
+	effectiveLogLevel := logLevel
+	if logLevel == "info" && cfg.Logging.Level != "" {
+		effectiveLogLevel = cfg.Logging.Level
+	}
+
+	log, err := logger.NewFileLoggerWithSeparateFormats(effectiveLogLevel, cfg.Logging.FilePath, cfg.Logging.Format, cfg.Logging.FileFormat)
+	if err != nil {
+		log = logger.NewLogger(effectiveLogLevel)
+		log.WithError(err).Warn("Failed to initialize file logger, using stdout")
+	}
+
+	if !cfg.Upload.Enabled {
+		log.Fatal("Upload is not enabled in configuration (upload.enabled: false)")
+	}
+
+	if _, err := os.Stat(sourcePath); os.IsNotExist(err) {
+		log.WithField("source_path", sourcePath).Fatal("Source path does not exist")
+	}
+
+	log.WithField("source_path", sourcePath).WithField("destination", cfg.Upload.Destination).Info("Starting upload")
+
+	if dryRun {
+		log.Info("DRY RUN MODE: No actual upload will be performed")
+		log.WithField("source_path", sourcePath).Info("Would upload this path")
+		log.WithField("destination", cfg.Upload.Destination).Info("Upload destination")
+		return
+	}
+
+	uploader := upload.NewService(&cfg.Upload, log)
+	if err := uploader.Upload(ctx, sourcePath); err != nil {
+		log.WithError(err).Fatal("Upload failed")
+	}
+
+	log.Info("Upload completed successfully")
 }

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -197,6 +197,39 @@ rclone copy minio:backups/db-2025-07-05_10-30-15 /tmp/restore/
 ./tenangdb restore --backup-path /backup/db-2025-07-05_10-30-15.tar.gz --database restored_db
 ```
 
+## ☁️ Upload Command
+
+Upload an existing backup file or directory to cloud storage without running a backup first.
+
+### Basic Usage
+```bash
+# Upload a backup directory
+./tenangdb upload --source-path /backup/myapp/2025-05/myapp-2025-05-26_10-30-15
+
+# Upload a compressed backup file
+./tenangdb upload --source-path /backup/myapp/2025-05/myapp-2025-05-26_10-30-15.tar.gz
+```
+
+### Options
+| Option | Description | Required |
+|--------|-------------|----------|
+| `--source-path, -s` | Path to backup file or directory to upload | ✅ |
+| `--config` | Path to configuration file | ❌ |
+| `--log-level` | Log level (debug, info, warn, error) | ❌ |
+| `--dry-run` | Preview what would be uploaded without executing | ❌ |
+
+### Examples
+```bash
+# Upload a mydumper backup directory
+./tenangdb upload --source-path /backup/prod_db-2025-05-26_10-30-15 --config config.yaml
+
+# Upload a compressed backup
+./tenangdb upload -s /backup/db-2025-05-26_10-30-15.tar.gz
+
+# Dry-run to preview upload destination
+./tenangdb upload --source-path /backup/prod_db-2025-05-26 --dry-run --config config.yaml
+```
+
 ## 🧹 Cleanup Command
 
 ### Confirmation Feature


### PR DESCRIPTION
Add `tenangdb upload --source-path <path>` subcommand to upload existing backup files/directories to cloud storage without requiring a backup run first. Uses the existing upload.Service.Upload() which already accepts arbitrary paths.

```
Flags:
  --source-path, -s  Path to backup file or directory (required)
  --config           Config file path (auto-discovery)
  --log-level        Log level (debug, info, warn, error)
  --dry-run          Preview without executing
```

Docs: added upload command section to COMMANDS.md