### PR TITLE
feat: add standalone dump command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,42 @@ bd automatically syncs with git:
 
 For more details, see README.md and docs/QUICKSTART.md.
 
+## Branching Convention
+
+**ALWAYS create a new branch for each bd ticket:**
+
+```bash
+bd create "Feature description" -t feature -p 2 --json
+# Use the returned ticket id for the branch name:
+git checkout -b feat/<ticket-id>
+
+# Or for bug fixes:
+git checkout -b fix/<ticket-id>
+```
+
+Common branch prefixes: `feat/`, `fix/`, `chore/`.
+
+## Quality Gates
+
+### Before Committing
+
+**ALWAYS run tests before committing feature code:**
+
+```bash
+go test ./... -count=1 -timeout 120s
+```
+
+If tests fail, fix them before committing. Never commit broken tests.
+
+### Post-Feature Checklist
+
+After implementing a new feature or changing behavior:
+- [ ] Update `docs/COMMANDS.md` if CLI command added or changed
+- [ ] Update `docs/CONFIGURATION.md` if config options changed
+- [ ] Update `README.md` if feature warrants top-level mention
+- [ ] Run `go build ./...` to verify compilation
+- [ ] Run `go test ./...` to verify tests pass
+
 ## Landing the Plane (Session Completion)
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/abdullahainun/tenangdb/internal/backup"
+	"github.com/abdullahainun/tenangdb/internal/compression"
 	"github.com/abdullahainun/tenangdb/internal/config"
 	"github.com/abdullahainun/tenangdb/internal/logger"
 	"github.com/abdullahainun/tenangdb/internal/metrics"
@@ -74,6 +75,9 @@ func main() {
 
 	// Add upload command
 	rootCmd.AddCommand(newUploadCommand())
+
+	// Add dump command
+	rootCmd.AddCommand(newDumpCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -2186,4 +2190,113 @@ func runUpload(configFile, logLevel, sourcePath string, dryRun bool) {
 	}
 
 	log.Info("Upload completed successfully")
+}
+
+func newDumpCommand() *cobra.Command {
+	var configFile string
+	var logLevel string
+	var dbName string
+	var outputDir string
+	var compress bool
+	var doUpload bool
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "dump",
+		Short: "Dump a single database without the full backup pipeline",
+		Long:  `Dump a single database directly to a local directory, with optional compression and cloud upload. Bypasses batch processing, frequency checks, confirmation prompts, and metrics.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runDump(configFile, logLevel, dbName, outputDir, compress, doUpload, dryRun)
+		},
+	}
+
+	cmd.Flags().StringVar(&configFile, "config", "", "config file path (auto-discovery if not specified)")
+	cmd.Flags().StringVar(&logLevel, "log-level", "info", "log level (debug, info, warn, error)")
+	cmd.Flags().StringVarP(&dbName, "database", "d", "", "database name to dump (required)")
+	cmd.Flags().StringVarP(&outputDir, "output", "o", "", "output directory (default: config backup.directory)")
+	cmd.Flags().BoolVar(&compress, "compress", false, "compress after dump (uses config backup.compression settings)")
+	cmd.Flags().BoolVar(&doUpload, "upload", false, "upload to cloud storage after dump")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be dumped without executing")
+
+	if err := cmd.MarkFlagRequired("database"); err != nil {
+		fmt.Printf("Error: Failed to mark database flag as required: %v\n", err)
+	}
+
+	return cmd
+}
+
+func runDump(configFile, logLevel, dbName, outputDir string, compress, doUpload, dryRun bool) {
+	ctx := context.Background()
+
+	cfg, err := config.LoadConfig(configFile)
+	if err != nil {
+		log := logger.NewLogger(logLevel)
+		log.WithError(err).Fatal("Failed to load configuration")
+	}
+
+	effectiveLogLevel := logLevel
+	if logLevel == "info" && cfg.Logging.Level != "" {
+		effectiveLogLevel = cfg.Logging.Level
+	}
+
+	log, err := logger.NewFileLoggerWithSeparateFormats(effectiveLogLevel, cfg.Logging.FilePath, cfg.Logging.Format, cfg.Logging.FileFormat)
+	if err != nil {
+		log = logger.NewLogger(effectiveLogLevel)
+		log.WithError(err).Warn("Failed to initialize file logger, using stdout")
+	}
+
+	if outputDir == "" {
+		outputDir = cfg.Backup.Directory
+	}
+
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		log.WithField("output_dir", outputDir).Fatal("Output directory does not exist")
+	}
+
+	log.WithField("database", dbName).WithField("output", outputDir).Info("Starting dump")
+
+	if dryRun {
+		log.Info("DRY RUN MODE: No actual dump will be performed")
+		log.WithField("database", dbName).Info("Would dump this database")
+		log.WithField("output_directory", outputDir).Info("Output directory")
+		if compress {
+			log.WithField("format", cfg.Backup.Compression.Format).Info("Would compress after dump")
+		}
+		if doUpload {
+			log.WithField("destination", cfg.Upload.Destination).Info("Would upload after dump")
+		}
+		return
+	}
+
+	dbClient, err := database.NewClient(&cfg.Database)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to initialize database client")
+	}
+	defer dbClient.Close()
+
+	backupPath, err := dbClient.CreateBackup(ctx, dbName, outputDir)
+	if err != nil {
+		log.WithError(err).Fatal("Dump failed")
+	}
+
+	finalPath := backupPath
+
+	if compress && cfg.Backup.Compression.Enabled {
+		comp := compression.NewCompressor(&cfg.Backup.Compression, log)
+		compressedPath, err := comp.CompressBackup(backupPath)
+		if err != nil {
+			log.WithError(err).Fatal("Compression failed")
+		}
+		finalPath = compressedPath
+	}
+
+	if doUpload && cfg.Upload.Enabled {
+		uploader := upload.NewService(&cfg.Upload, log)
+		if err := uploader.Upload(ctx, finalPath); err != nil {
+			log.WithError(err).Fatal("Upload failed")
+		}
+		log.Info("Upload completed")
+	}
+
+	log.WithField("output", finalPath).Info("Dump completed successfully")
 }

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,7 +11,9 @@ tenangdb [command] [options]
 ### Available Commands
 - `init` - Interactive setup wizard (NEW!)
 - `backup` - Run database backup (default)
+- `dump` - Dump a single database directly
 - `restore` - Restore database from backup
+- `upload` - Upload existing backup to cloud storage
 - `cleanup` - Clean up old backup files
 - `config` - Show configuration information
 - `version` - Show version information
@@ -228,6 +230,51 @@ Upload an existing backup file or directory to cloud storage without running a b
 
 # Dry-run to preview upload destination
 ./tenangdb upload --source-path /backup/prod_db-2025-05-26 --dry-run --config config.yaml
+```
+
+## 📤 Dump Command
+
+Dump a single database directly without running the full backup pipeline. Bypasses batch processing, frequency checks, confirmation prompts, and metrics tracking.
+
+### Basic Usage
+```bash
+# Dump a single database
+./tenangdb dump --database mydb
+
+# Dump to a specific output directory
+./tenangdb dump -d mydb -o /custom/backup/path
+
+# Dump, compress, and upload in one step
+./tenangdb dump -d mydb --compress --upload --config config.yaml
+```
+
+### Options
+| Option | Description | Required |
+|--------|-------------|----------|
+| `--database, -d` | Database name to dump | ✅ |
+| `--output, -o` | Output directory (default: config backup.directory) | ❌ |
+| `--config` | Path to configuration file | ❌ |
+| `--log-level` | Log level (debug, info, warn, error) | ❌ |
+| `--compress` | Compress after dump (uses config backup.compression settings) | ❌ |
+| `--upload` | Upload to cloud storage after dump | ❌ |
+| `--dry-run` | Preview what would be dumped without executing | ❌ |
+
+### Examples
+```bash
+# Dump a single database using default config and output directory
+./tenangdb dump --database prod_db --config config.yaml
+
+# Dump to a specific directory with compression
+./tenangdb dump -d mydb -o /var/backups/adhoc --compress
+
+# Dump, compress, and upload to cloud in one command
+./tenangdb dump -d critical_db --compress --upload --config config.yaml
+
+# Preview what would happen without executing
+./tenangdb dump -d mydb --compress --upload --dry-run
+
+# Chain with upload standalone for manual workflow
+./tenangdb dump -d mydb -o /tmp && tenangdb upload -s /tmp/mydb/2026-05/mydb-2026-05-28_10-30-15.tar.gz
 ```
 
 ## 🧹 Cleanup Command


### PR DESCRIPTION
Add  subcommand that dumps a single database directly without the full backup pipeline (batch processing, frequency checks, confirmation prompts, metrics).

```
Flags:
  -d, --database  Database name to dump (required)
  -o, --output    Output directory (default: config backup.directory)
  --compress      Compress after dump
  --upload        Upload to cloud after dump
  --dry-run       Preview only
```
Also update:
  - docs/COMMANDS.md: Add dump + upload to command overview, dump section
  - AGENTS.md: Add branching convention, quality gates, docs checklist

Closes tenangdb-33j